### PR TITLE
Fix an exception on page 'plant' with a fresh installation

### DIFF
--- a/src/AppBundle/Repository/PlantRepository.php
+++ b/src/AppBundle/Repository/PlantRepository.php
@@ -56,8 +56,9 @@ class PlantRepository extends AbstractRepository
             ->innerJoin('AppBundle:Seed', 's', 'WITH', 'p.seed = s.id')
             ->innerJoin('AppBundle:Area', 'a', 'WITH', 'p.area = a.id')
             ->innerJoin('AppBundle:SeedCategory', 'sc', 'WITH', 's.seedCategory = sc.id')
-            ->where('a.field = '.$farmId)
+            ->where('a.field = :farm_id')
             ->groupBy('p.seed')
+            ->setParameter('farm_id', $farmId)
             ->getQuery();
 
         return $query->getResult();


### PR DESCRIPTION
With a fresh installation $farmId is null, so sql part will be 'a.field ='. 